### PR TITLE
Fixing an error when running step 2-3 with count variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ Mind that this script will use only 3 digits of the ICD9 diagnosis code. If you 
 `python medgan.py <matrix file> <output path> --data_type=["binary", "count"]`.
 
 3. After the training, if you want to generate synthetic records, use this command :
-`python medgan.py <matrix file> <generated output path> --model_file=<trained output path> --generate_data=True`.
+`python medgan.py <matrix file> <generated output path> --model_file=<trained output path> --generate_data=True --data_type=["binary", "count"]`.
 Note that `<matrix file>` is not actually used for generating synthetic records, so it is just a dummy input.


### PR DESCRIPTION
After running step 2-3 (after the training, to generate the synthetic records) with count variables, all the values of my synthetic records were between 0 and 1, thus binary after rounding. It seems that the default value of `medgan.py` is `--data_type="binary"`  so we need to add the argument `--data_type="count"` in the final step (if we have count variable instead of binary ones).